### PR TITLE
Allow more than one outstanding command

### DIFF
--- a/lib/LineUs.js
+++ b/lib/LineUs.js
@@ -62,7 +62,9 @@ class LineUs extends Nanobus {
   connect() {
     this.state = 'connecting'
     this._ws = new WebSocket(this.url)
-    this._ws.setMaxListeners(this.concurrency + 1)
+    if (typeof(this._ws['setMaxListeners']) === 'function') {
+      this._ws.setMaxListeners(this.concurrency + 1)
+    }
 
     this._ws.onopen = async () => {
       let response = await pEvent(this._ws, 'message') // wait for hello

--- a/lib/LineUs.js
+++ b/lib/LineUs.js
@@ -34,8 +34,8 @@ class LineUs extends Nanobus {
     this._coordinates = {}
     this._queuedPenState = 'up'
 
-    this.sendCounter = 0;
-    this.replyCounter = 0;
+    this.sendCounter = 0
+    this.replyCounter = 0
 
     if (this.autoConnect) {
       this.connect()
@@ -172,7 +172,7 @@ class LineUs extends Nanobus {
     let response
     do {
       response = await responseEvent
-    } while (this.replyCounter != myCounter )
+    } while (this.replyCounter !== myCounter)
     this.replyCounter++
 
     response = deserialize(response.data || response)

--- a/lib/LineUs.js
+++ b/lib/LineUs.js
@@ -62,9 +62,6 @@ class LineUs extends Nanobus {
   connect() {
     this.state = 'connecting'
     this._ws = new WebSocket(this.url)
-    if (typeof(this._ws['setMaxListeners']) === 'function') {
-      this._ws.setMaxListeners(this.concurrency + 1)
-    }
 
     this._ws.onopen = async () => {
       let response = await pEvent(this._ws, 'message') // wait for hello
@@ -89,6 +86,11 @@ class LineUs extends Nanobus {
 
     this._ws.onerror = (e) => {
       this.emit('error', 'LineUs: websocket error: ' + e.error.message)
+    }
+
+    this._ws.onmessage = (e) => {
+      this.emit(String(this.replyCounter), e)
+      this.replyCounter++
     }
   }
 
@@ -168,14 +170,10 @@ class LineUs extends Nanobus {
 
   async _send(cmd) {
     const myCounter = this.sendCounter++
-    const responseEvent = pEvent(this._ws, 'message')
+    const responseEvent = pEvent(this, String(myCounter))
     this._ws.send(serialize(cmd))
 
-    let response
-    do {
-      response = await responseEvent
-    } while (this.replyCounter !== myCounter)
-    this.replyCounter++
+    let response = await responseEvent
 
     response = deserialize(response.data || response)
 

--- a/lib/LineUs.js
+++ b/lib/LineUs.js
@@ -15,6 +15,7 @@ class LineUs extends Nanobus {
         url: 'ws://line-us.local',
         autoConnect: true,
         autoStart: true,
+        concurrency: 1,
       },
       opts
     )
@@ -23,15 +24,18 @@ class LineUs extends Nanobus {
     this.url = opts.url
     this.autoConnect = opts.autoConnect
     this.autoStart = opts.autoStart
+    this.concurrency = opts.concurrency
 
     this.info = {} // populated by `hello` message from Line-us
 
     this._ws = null
-    this._queue = new pQueue({ concurrency: 1, autoStart: false })
-
+    this._queue = new pQueue({ concurrency: this.concurrency, autoStart: false })
     this._state = 'disconnected'
     this._coordinates = {}
     this._queuedPenState = 'up'
+
+    this.sendCounter = 0;
+    this.replyCounter = 0;
 
     if (this.autoConnect) {
       this.connect()
@@ -58,6 +62,7 @@ class LineUs extends Nanobus {
   connect() {
     this.state = 'connecting'
     this._ws = new WebSocket(this.url)
+    this._ws.setMaxListeners(this.concurrency + 1)
 
     this._ws.onopen = async () => {
       let response = await pEvent(this._ws, 'message') // wait for hello
@@ -160,10 +165,16 @@ class LineUs extends Nanobus {
   }
 
   async _send(cmd) {
+    const myCounter = this.sendCounter++
     const responseEvent = pEvent(this._ws, 'message')
     this._ws.send(serialize(cmd))
 
-    let response = await responseEvent
+    let response
+    do {
+      response = await responseEvent
+    } while (this.replyCounter != myCounter )
+    this.replyCounter++
+
     response = deserialize(response.data || response)
 
     switch (response.type) {

--- a/lib/LineUs.js
+++ b/lib/LineUs.js
@@ -72,6 +72,11 @@ class LineUs extends Nanobus {
       this._queuedPenState = 'up' // should be at home position right now
       this.coordinates = { x: 350, y: 0, z: 1000 }
 
+      this._ws.onmessage = (e) => {
+        this.emit(String(this.replyCounter), e.data)
+        this.replyCounter++
+      }
+
       if (this.autoStart) {
         this.start()
       } else {
@@ -86,11 +91,6 @@ class LineUs extends Nanobus {
 
     this._ws.onerror = (e) => {
       this.emit('error', 'LineUs: websocket error: ' + e.error.message)
-    }
-
-    this._ws.onmessage = (e) => {
-      this.emit(String(this.replyCounter), e)
-      this.replyCounter++
     }
   }
 


### PR DESCRIPTION
We've been doing some testing with the WS interface on Line-us and the restriction on having to wait for the 'OK' response before sending the next command isn't necessary with firmware >= 3.0.0. This means we can improve drawing speed, particularly on slow connections (we're also testing remote access to Line-us so this is a big plus!).

I've made a change to the library to allow multiple outstanding commands - not sure whether the approach is the best way to go about it so let me know if not. The logic is as follows:

1. There are two counters `sendCounter` and `replyCounter` both initialised to 0
1. When a command is sent it stores a copy of the current `sendCounter` in `myCounter` and then increments `sendCounter`.
1. All of the outstanding commands listen for the `message` event. If their `myCounter` is not equal to `replyCounter` they wait again, but if it is equal then we assume it's the response to their command. It increments `replyCounter` and carries on as before.

The obvious shortcoming is that there are potentially many listeners responding to the event when only one needs to take action. I'm not sure whether this is an issue - not enough of a JS programmer to know (there are likely to be between 5 and 30 outstanding commands in real world use).

If this is likely to be a problem then an option might be to have a single listener for `message` that then re-issues an event something like `message1234` where `1234` is the `replyCounter`. Obviously then you just have one response to the event but there are a lot of event types.

Let me know what you think!